### PR TITLE
fix dependency to patched polygon class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,9 @@ dependencies {
     compile group: 'eu.mihosoft.vvecmath', name: 'vvecmath', version: '0.3.8', classifier: 'sources'
     
     // jcsg library
-    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.6'
-    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.6', classifier: 'sources'
-    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.6', classifier: 'javadoc'
+    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.7'
+    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.7', classifier: 'sources'
+    compile group: 'eu.mihosoft.vrl.jcsg', name: 'jcsg', version: '0.5.7', classifier: 'javadoc'
 
 }
 


### PR DESCRIPTION
You are referencing a jcsg dependency version which has a getter (getPlane()) for the Plane in the Polygon class 

ExtrudeProfile.java was fixed to use getPlane() (instead of trying to accesss the private plane field directly) which is not available in the referenced jcsg dependency 0.5.6 but in 0.5.7